### PR TITLE
31.Cloud Formationを使った運用監視の環境構成　課題修正

### DIFF
--- a/infrastructure.drawio/aws-study.yaml
+++ b/infrastructure.drawio/aws-study.yaml
@@ -393,10 +393,7 @@ Resources:
     Properties:
       ResourceArn: !GetAtt WebACL.Arn
       LogDestinationConfigs:
-        - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:aws-waf-logs-${AWS::StackName}"
-    DependsOn:
-      - WAFLogGroup
-      - WebACL
+        - !GetAtt WAFLogGroup.Arn 
       
 # -----------------------
 # CloudWatch Logs

--- a/infrastructure.drawio/aws-study.yaml
+++ b/infrastructure.drawio/aws-study.yaml
@@ -386,6 +386,19 @@ Resources:
       WebACLArn: !GetAtt WebACL.Arn 
 
 # -----------------------
+# WAF Logging Configuration
+# -----------------------
+  WAFLoggingConfiguration:
+    Type: AWS::WAFv2::LoggingConfiguration
+    Properties:
+      ResourceArn: !GetAtt WebACL.Arn
+      LogDestinationConfigs:
+        - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:aws-waf-logs-${AWS::StackName}"
+    DependsOn:
+      - WAFLogGroup
+      - WebACL
+      
+# -----------------------
 # CloudWatch Logs
 # -----------------------
   WAFLogGroup: 


### PR DESCRIPTION
# WAF Logging Configurationの追加

## 実装内容
WAFのログをCloudWatch Logsに出力するための設定を削除していたため、`AWS::WAFv2::LoggingConfiguration` リソースを追加しました。

## 背景・問題
テンプレートには `WAFLogGroup`（ロググループ）が定義されていたものの、WAF側にログ送信先を紐づける `LoggingConfiguration` が未定義の状態でした。そのため、実態としてWAFログはCloudWatch Logsに出力されていませんでした。

## 修正内容
・ WAFLoggingConfigurationの設定変更をする
・ cfn-lintでスタック作成前に、動作確認をする
・  スタック作成後の動作確認をし、証跡となるスクショを1,2,3に添付する

## 確認方法
1. スタックデプロイ後、
ターミナルで以下を実行。ELBDNS名&/ブロックテスト
WAFアラーム確認。自分のスマホでメール通知確認しました。

<img width="953" height="442" alt="スクリーンショット 2026-05-18 092848" src="https://github.com/user-attachments/assets/01cca9b6-4f6c-42e7-95ae-cd4371e63c71" />



2.WAFコンソール → 該当WebACL → 「Logging and metrics」タブでロググループ名が表示されていることを確認

<img width="959" height="441" alt="スクリーンショット 2026-05-18 092806" src="https://github.com/user-attachments/assets/6e7852c3-5c6c-4e90-b6b4-89da193e0f09" />


3. CloudWatch Logs → `aws-waf-logs-{スタック名}` にログストリームとJSONログが出力されていることを確認（ログストリームのログが1枚で収まらなかったため、2枚添付しています）

<img width="959" height="417" alt="スクリーンショット 2026-05-18 092659" src="https://github.com/user-attachments/assets/f2e04a8e-0fc8-414f-baef-1fe04ccbe8fd" />
<img width="958" height="417" alt="スクリーンショット 2026-05-18 092720" src="https://github.com/user-attachments/assets/3b984e8a-8fc9-4ad7-b992-2021c57e121f" />


## 学んだこと
背景として、CloudWatchlogsのログストリームからログ出力を確認できていたため、今回リソース追加したWAF Logging Configurationがなくても、連携できていると感じていたが、今確認しているグループ名やwafのリソースは間違っていないか確認したところ、別のwafリソースからログ出力を確認していたことに気づいた。
できていると思っていたことが、見ていたリソース名が違っただけで本当はできていなかった。
といった勘違いミスをしたことを今回のPRで学べたので、次回から見ているものは本当に正しいものなのかまで、慎重に確認していこうと思いました!

