### PR TITLE
feat: move EC2 to private subnet with NAT Gateway

### DIFF
--- a/terraform/ec2.tf
+++ b/terraform/ec2.tf
@@ -59,7 +59,7 @@ resource "aws_iam_instance_profile" "ec2" {
 resource "aws_instance" "main" {
   ami                                  = data.aws_ami.amazon_linux_2023.id
   instance_type                        = "t2.micro"
-  subnet_id                            = aws_subnet.public_a.id
+  subnet_id                            = aws_subnet.private_a.id
   vpc_security_group_ids               = [aws_security_group.ec2.id]
   iam_instance_profile                 = aws_iam_instance_profile.ec2.name
   disable_api_termination              = false

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -106,3 +106,57 @@ resource "aws_route_table_association" "public_c" {
   subnet_id      = aws_subnet.public_c.id
   route_table_id = aws_route_table.public.id
 }
+
+# ---------------
+# Elastic IP (NAT Gateway用)
+# ---------------
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = {
+    Name = "aws-study-nat-eip"
+  }
+}
+
+# ---------------
+# NAT Gateway
+# ---------------
+resource "aws_nat_gateway" "main" {
+  allocation_id = aws_eip.nat.id 
+  subnet_id     = aws_subnet.public_a.id
+
+  tags = {
+    Name = "aws-study-nat-gw"
+  }
+
+  depends_on = [aws_internet_gateway.main]
+}
+
+# ---------------
+# Route Table (Private)
+# ---------------
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.main.id 
+  }
+
+  tags = {
+    Name = "aws-study-private-route"
+  }
+}
+
+# ---------------
+# Route Table Association (Private)
+# ---------------
+resource "aws_route_table_association" "private_a" {
+  subnet_id      = aws_subnet.private_a.id
+  route_table_id = aws_route_table.private.id   
+}
+
+resource "aws_route_table_association" "private_c" {
+  subnet_id      = aws_subnet.private_c.id
+  route_table_id = aws_route_table.private.id 
+}


### PR DESCRIPTION
## 変更内容
- EC2をPublicSubnetからPrivateSubnetに移動
- NAT Gatewayを追加（EC2からの外部通信用）
- Privateサブネット用ルートテーブルを追加

## 理由
セキュリティ強化のため、EC2をプライベートサブネットに隔離。
EC2へのアクセスはSSM Session Manager経由のみに限定。