### PR TITLE
40_インフラ環境の自動テスト 課題提出

### DIFF
--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -62,8 +62,8 @@ resource "aws_db_instance" "main" {
   allow_major_version_upgrade = false
   auto_minor_version_upgrade  = true
   license_model               = "general-public-license"
-  deletion_protection         = false
-  skip_final_snapshot         = true
+  deletion_protection         = true
+  skip_final_snapshot         = false
 
   tags = {
     Name = "mydb"

--- a/terraform/tests/cloudwatch_sg_test.tftest.hcl
+++ b/terraform/tests/cloudwatch_sg_test.tftest.hcl
@@ -53,4 +53,19 @@ run "security_group_plan_check" {
     condition = anytrue([for rule in aws_security_group.rds.ingress : rule.from_port == 3306])
     error_message = "RDS SGのingressポートが3306ではありません"
   }
+
+  assert {
+    condition = alltrue([for rule in aws_security_group.elb.ingress : rule.from_port != 22])
+    error_message = "ELB SGにSSHポート(22)が開放されています"
+  }
+
+  assert {
+    condition = alltrue([for rule in aws_security_group.ec2.ingress : rule.from_port != 22])
+    error_message = "EC2 SGにSSHポート(22)が開放されています"
+  }
+
+  assert {
+    condition = alltrue([for rule in aws_security_group.rds.ingress : rule.from_port != 22])
+    error_message = "RDS SGにSSHポート(22)が開放されています"
+  }
 }

--- a/terraform/tests/cloudwatch_sg_test.tftest.hcl
+++ b/terraform/tests/cloudwatch_sg_test.tftest.hcl
@@ -1,0 +1,56 @@
+variables {
+  notification_email = "test@example.com"
+}
+
+run "cloudwatch_plan_check" {
+  command = plan 
+
+  assert {
+    condition = aws_cloudwatch_metric_alarm.ec2_cpu.threshold == 70
+    error_message = "EC2 CPUアラームのthresholdが70ではありません"
+  }
+
+  assert {
+    condition = aws_cloudwatch_metric_alarm.ec2_cpu.period == 300
+    error_message = "EC2 CPUアラームのperiodが300ではありません"
+  }
+
+  assert {
+    condition = aws_cloudwatch_metric_alarm.ec2_cpu.evaluation_periods == 3
+    error_message = "EC2 CPUアラームのevaluation_periodsが3ではありません"
+  }
+
+  assert {
+    condition = aws_cloudwatch_metric_alarm.elb_5xx.threshold == 5
+    error_message = "ELB 5xxアラームのthresholdが5ではありません"
+  }
+
+  assert {
+    condition = aws_sns_topic.alarm.name == "aws-study-alarm-topic"
+    error_message = "SNS Topicの名前が想定と異なります"
+  }
+
+  assert {
+    condition = aws_sns_topic_subscription.email.protocol == "email"
+    error_message = "SNS Subscriptionのprotocolがemailではありません"
+  }
+}
+
+run "security_group_plan_check" {
+  command = plan
+
+  assert {
+    condition =  anytrue([for rule in aws_security_group.elb.ingress : rule.from_port == 80])
+    error_message = "ELB SGのingressポートが80ではありません"
+  }
+
+  assert {
+    condition = anytrue([for rule in aws_security_group.ec2.ingress : rule.from_port == 8080])
+    error_message = "EC2 SGのingressポートが8080ではありません"
+  }
+
+  assert {
+    condition = anytrue([for rule in aws_security_group.rds.ingress : rule.from_port == 3306])
+    error_message = "RDS SGのingressポートが3306ではありません"
+  }
+}

--- a/terraform/tests/rds_elb_test.tftest.hcl
+++ b/terraform/tests/rds_elb_test.tftest.hcl
@@ -1,0 +1,61 @@
+variables {
+  notification_email = "test@example.com"
+}
+
+run "rds_plan_check" {
+  command = plan
+
+  assert { 
+    condition     = aws_db_instance.main.engine == "mysql"
+    error_message = "RDSのエンジンがmysqlではありません"
+  }
+
+  assert {
+    condition     = aws_db_instance.main.engine_version == "8.0"
+    error_message = "RDSのエンジンバージョンが8.0ではありません"
+  }
+
+  assert {
+    condition = aws_db_instance.main.instance_class == "db.t4g.micro"
+    error_message = "RDSのインスタンスクラスが異なります"
+  }
+
+  assert {
+    condition = aws_db_instance.main.allocated_storage == 20
+    error_message = "RDSのストレージが20GBではありません"
+  }
+
+  assert {
+    condition = aws_db_instance.main.deletion_protection == false
+    error_message = "deletion_protectionがfalseではありません"
+  }
+
+  assert {
+    condition = aws_db_instance.main.skip_final_snapshot == true
+    error_message = "skip_final_snapshotがtrueではありません"
+  }
+}
+
+run "elb_plan_check"{
+  command = plan
+
+  assert {
+    condition = aws_lb.main.load_balancer_type == "application"
+    error_message = "ELBのタイプがapplicationではありません"
+  }
+
+  assert {
+    condition = aws_lb_listener.main.port == 80
+    error_message = "ELBリスナーのポートが80ではありません"
+  }
+
+  assert {
+    condition = aws_lb_listener.main.protocol == "HTTP"
+    error_message = "ELBリスナーのプロトコルがHTTPではありません"
+  }
+
+  assert {
+    condition = aws_lb_target_group.main.port == 8080
+    error_message = "TargetGroupのポートが8080ではありません"
+  }
+}

--- a/terraform/tests/rds_elb_test.tftest.hcl
+++ b/terraform/tests/rds_elb_test.tftest.hcl
@@ -26,13 +26,13 @@ run "rds_plan_check" {
   }
 
   assert {
-    condition = aws_db_instance.main.deletion_protection == false
-    error_message = "deletion_protectionがfalseではありません"
+    condition = aws_db_instance.main.deletion_protection == true
+    error_message = "deletion_protectionがtrueではありません"
   }
 
   assert {
-    condition = aws_db_instance.main.skip_final_snapshot == true
-    error_message = "skip_final_snapshotがtrueではありません"
+    condition = aws_db_instance.main.skip_final_snapshot == false
+    error_message = "skip_final_snapshotがfalseではありません"
   }
 }
 

--- a/terraform/tests/waf_test.tftest.hcl
+++ b/terraform/tests/waf_test.tftest.hcl
@@ -1,0 +1,32 @@
+variables {
+  notification_email = "test@example.com"
+}
+
+run "waf_plan_check" {
+  command = plan 
+
+  assert {
+    condition = aws_wafv2_web_acl.main.scope == "REGIONAL"
+    error_message = "WAF Web ACLのscopeがREGIONALではありません"
+  }
+
+  assert {
+    condition = aws_cloudwatch_log_group.waf.retention_in_days == 14
+    error_message = "CloudWatch Log Groupの保持期間が14日ではありません"
+  }
+
+  assert {
+    condition = aws_cloudwatch_log_group.waf.name == "aws-waf-logs-aws-study"
+    error_message = "CloudWatch Log Groupの名前が想定と異なります"
+  }
+
+  assert {
+    condition     = anytrue([for rule in aws_wafv2_web_acl.main.rule : rule.name == "BlockTestURI" && rule.priority == 0])
+    error_message = "BlockTestURIルールのpriorityが0ではありません"
+  }
+
+  assert {
+    condition     = anytrue([for rule in aws_wafv2_web_acl.main.rule : rule.name == "AWS-AWSManagedRulesCommonRuleSet" && rule.priority == 1])
+    error_message = "AWSManagedRulesCommonRuleSetのpriorityが1ではありません"
+  }
+}  


### PR DESCRIPTION
### test: Terraformテストコードの追加（RDS/ELB/CloudWatch/SG/WAF）

## 概要
Terraformで定義したAWSリソースに対して、設計の意図が守られているかを検証するテストコードを追加しました。

## 変更内容
- terraform/tests/rds_elb_test.tftest.hcl を追加
- terraform/tests/cloudwatch_sg_test.tftest.hcl を追加
- terraform/tests/waf_test.tftest.hcl を追加

## 修正内容
1.terrafoem/rds.tf & terraform/tests/rds_elb_test.tftest.hcl の機能変更
2.terraform/tests/cloudwatch_sg_test.tftest.hclのtestコード追加
3..\terrafirm testでテスト確認済み

## テスト観点
### RDS
- エンジンが"mysql"であること
- インスタンスクラスが"db.t4g.micro"であること
- ストレージが"20GB"であること

### ELB 
- ロードバランサータイプが"application"であること
- リスナーボードが"80"であること
- ターゲットグループのポートが"8080"であること

### CloudWatch
- EC2 CPUアラームのthresholdが"70"であること
- SNS Subscriptionのprotocolが"e-mail"であること

### Security Group
- ELB SG のingressポートが"80"であること
- EC2 SGのingressポートが"8080"であること
- RDS SGのingressポートが"3306"であること
- 全てのポート22が 0.0.0.0/0 に開いていないこと

### WAF
- Web ACLのscopeが"REGIONAL"であること
- ログ保持期間が"14日"であること

## 動作確認
.\terraform test を実行し、全テストがパスしたことを確認しました。

<img width="422" height="328" alt="スクリーンショット 2026-06-28 151405" src="https://github.com/user-attachments/assets/b678325c-b3f8-4591-94ec-46812b95814b" />


## 補足
誤って下記の2点はマージしてしまったので、次回マージしてしまわないよう気を付けます。以下、２点もテストは完了済みです。

terraform/test/variables_test.tftest.hcl
terraform/test/vpc_ec2_test.tftest.hcl

## 学んだこと
テストすべき項目を知ることができた
- セキュリティリスク になる設定
-  コスト爆発 につながる設定
-  設計の意図 が壊れる設定
また、terraformのドキュメントを見て、terraformの型別に用いるものが違うことも知ることができた。いまいち、理解できてはいないため、テストコードの検証方法は書きながら学ぶことができたので、進めていきながら理解できるようにしていこうと思う!